### PR TITLE
README: specs.md -> spec.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A json data such as {"hello":"world"} is serialized in binn as:
   \x05world\x00  // value (null terminated)
 </pre>
 
-You can check the [complete specification](specs.md)
+You can check the [complete specification](spec.md)
 
 Usage Example
 -------------


### PR DESCRIPTION
Fix a typo in `README.md` that linked to the missing file `specs.md` instead of `spec.md`.