### PR TITLE
Fix missing header for size_t

### DIFF
--- a/src/binn.h
+++ b/src/binn.h
@@ -7,11 +7,11 @@
 #ifndef BINN_H
 #define BINN_H
 
-#include <stddef.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#include <stddef.h>
 
 #define BINN_VERSION "3.0.0"  /* using semantic versioning */
 

--- a/src/binn.h
+++ b/src/binn.h
@@ -7,6 +7,8 @@
 #ifndef BINN_H
 #define BINN_H
 
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Without this standard C header it doesn't compile with following error:

`src\binn.h(259): error C2081: 'size_t': name in formal parameter list illegal`

Library itself (`binn.c`) compiles normally because it includes other standard headers before `binn.h` so `binn.h` receives `size_t` definition. But if you include `binn.h` in some other C file (like in `writing.c`) and don't include other headers, it won't compile.
`stddef.h` is standard header so I think it should be okay to include that. All compilers should support it.